### PR TITLE
Concept proof: capture learnr user_id manually

### DIFF
--- a/learnr-module/tutorial.Rmd
+++ b/learnr-module/tutorial.Rmd
@@ -55,6 +55,15 @@ options(tutorial.event_recorder = tutorial_event_recorder)
 
 ```
 
+```{r, context="server"}
+
+# get the default user ID used by the learnr module
+userID <- unname(Sys.info()["user"])
+# save the user ID
+saveRDS(userID, file = "userID.Rds")
+
+```
+
 ```{r child = "introduction.Rmd"}
 ```
 


### PR DESCRIPTION
Searching through the `learnr` code [identifiers.R](https://rdrr.io/cran/learnr/src/R/identifiers.R) and [events.R](https://rdrr.io/cran/learnr/src/R/events.R), they initialize the `user_id` using `Sys.info()["user"]`. Adding the chunk works on my local machine. I am not 100% sure if/when the `user_id` variable gets changed, so this should be tested more explicitly. However, I **think** that it only gets changed if a custom identifier is defined (see [here](https://rstudio.github.io/learnr/publishing.html#Tutorial_Identifiers)). The code would also have to be updated for persistent storage with Dropbox, which I would love to learn how to do.