### PR TITLE
Switch to single upload of event data and use a future promise

### DIFF
--- a/learnr-b/setup.Rmd
+++ b/learnr-b/setup.Rmd
@@ -29,41 +29,34 @@ if (!base::is.null(query[["user_id"]])) {
   return(user_id)
 }
 
+# Setup how the async is run
+future::plan("multisession")
 
 tutorial_event_recorder <- function(username) {
-
-  recorder <- function(tutorial_id, tutorial_version, user_id,
-                       event, data) {
-    if (rdrop2::drop_exists(glue::glue("/D'Agostino McGowan Data Science Lab/learnr_results/data_{username}.rds"))) {
-      rdrop2::drop_download(path = glue::glue("/D'Agostino McGowan Data Science Lab/learnr_results/data_{username}.rds"),
-                    local_path = glue::glue("data_{username}.rds"),
-                    overwrite = TRUE)
-      t <- readRDS(glue::glue("data_{username}.rds"))
-    } else {
-      t <- tibble::tibble(
-        username = username,
-        time = .POSIXct(numeric(0)),
-        tutorial_id = character(),
-        tutorial_version = character(),
-        user_id = character(),
-        event = character(),
-        data = list())
-
-    }
-    t <- dplyr::bind_rows(t,
-                   tibble::tibble(
-                     username = username,
-                     time = Sys.time(),
-                     tutorial_id = tutorial_id,
-                     tutorial_version = tutorial_version,
-                     user_id = user_id,
-                     event = event,
-                     data = list(data)
-                   )
+  recorder <- function(tutorial_id, tutorial_version, user_id, event, data) {
+    current_time <- Sys.time()
+    event_info <- tibble::tibble(
+      username = username,
+      time = current_time,
+      tutorial_id = tutorial_id,
+      tutorial_version = tutorial_version,
+      user_id = user_id,
+      event = event,
+      data = list(data)
     )
-    saveRDS(t, file = glue::glue("data_{username}.rds"))
-    rdrop2::drop_upload(file = glue::glue("data_{username}.rds"),
-                path = "/D'Agostino McGowan Data Science Lab/learnr_results/")
+    file_name <- glue::glue("data_{username}_t{as.numeric(current_time)}.rds")
+    saveRDS(event_info, file = file_name)
+    
+    # Unlink file to avoid filling up disk
+    on.exit(unlink(file_name), add = TRUE)
+    
+    # Run the dropbox upload as an async promise so it doesn't block the main
+    # thread and slow things down
+    promises::future_promise({
+      rdrop2::drop_upload(file = file_name,
+                          autorename = TRUE, # Just incase default changes make sure conflicts arent swallowed
+                          path = "/D'Agostino McGowan Data Science Lab/learnr_results/")
+    })
   }
   recorder
 }


### PR DESCRIPTION
By avoiding the checking of a file and downloading of existing files we save a lot of slowness caused by waiting for external server responses. 
The difference here is later you will need to go through and process the many smaller files but that's a one-time-thing. 

The future promise will also take the slow upload onto another worker to avoid slowing down your app. 

Make sure you have the latest version of promises to get `promises::future_promise()`.